### PR TITLE
Feature/2 rebranding deep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .vscode
 
 # Tree service
-internal/neofs/services/tree/
+internal/frostfs/services/tree/
 
 # Vendoring
 vendor

--- a/api/auth/center.go
+++ b/api/auth/center.go
@@ -92,9 +92,9 @@ func (p prs) Seek(_ int64, _ int) (int64, error) {
 var _ io.ReadSeeker = prs(0)
 
 // New creates an instance of AuthCenter.
-func New(neoFS tokens.NeoFS, key *keys.PrivateKey, prefixes []string, config *cache.Config) Center {
+func New(frostFS tokens.FrostFS, key *keys.PrivateKey, prefixes []string, config *cache.Config) Center {
 	return &center{
-		cli:                        tokens.New(neoFS, key, config),
+		cli:                        tokens.New(frostFS, key, config),
 		reg:                        NewRegexpMatcher(authorizationFieldRegexp),
 		postReg:                    NewRegexpMatcher(postPolicyCredentialRegexp),
 		allowedAccessKeyIDPrefixes: prefixes,

--- a/api/cache/objectslist.go
+++ b/api/cache/objectslist.go
@@ -20,7 +20,7 @@ import (
 	After putting a record, it lives for a while (default value is 60 seconds).
 
 	When we receive a request from a user, we try to find the suitable and non-expired cache entry, go through the list
-	and get ObjectInfos from common object cache or with a request to NeoFS.
+	and get ObjectInfos from common object cache or with a request to FrostFS.
 
 	When we put an object into a container, we invalidate entries with prefixes that are prefixes of the object's name.
 */

--- a/api/data/tree.go
+++ b/api/data/tree.go
@@ -25,7 +25,7 @@ func (v NodeVersion) IsDeleteMarker() bool {
 }
 
 // DeleteMarkerInfo is used to save object info if node in the tree service is delete marker.
-// We need this information because the "delete marker" object is no longer stored in NeoFS.
+// We need this information because the "delete marker" object is no longer stored in FrostFS.
 type DeleteMarkerInfo struct {
 	Created time.Time
 	Owner   user.ID

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -986,7 +986,7 @@ var errorCodes = errorCodeMap{
 	ErrNotSupported: {
 		ErrCode:        ErrNotSupported,
 		Code:           "BadRequest",
-		Description:    "Not supported by NeoFS S3 Gateway",
+		Description:    "Not supported by FrostFS S3 Gateway",
 		HTTPStatusCode: http.StatusNotImplemented,
 	},
 	ErrInvalidEncryptionMethod: {

--- a/api/handler/api.go
+++ b/api/handler/api.go
@@ -38,7 +38,7 @@ type (
 )
 
 const (
-	// DefaultPolicy is a default policy of placing containers in NeoFS if it's not set at the request.
+	// DefaultPolicy is a default policy of placing containers in FrostFS if it's not set at the request.
 	DefaultPolicy = "REP 3"
 	// DefaultCopiesNumber is a default number of object copies that is enough to consider put successful if it's not set in config.
 	DefaultCopiesNumber uint32 = 0
@@ -50,7 +50,7 @@ var _ api.Handler = (*handler)(nil)
 func New(log *zap.Logger, obj layer.Client, notificator Notificator, cfg *Config) (api.Handler, error) {
 	switch {
 	case obj == nil:
-		return nil, errors.New("empty NeoFS Object Layer")
+		return nil, errors.New("empty FrostFS Object Layer")
 	case log == nil:
 		return nil, errors.New("empty logger")
 	}

--- a/api/handler/delete_test.go
+++ b/api/handler/delete_test.go
@@ -41,7 +41,7 @@ func TestDeleteObject(t *testing.T) {
 	deleteObject(t, tc, bktName, objName, emptyVersion)
 	checkNotFound(t, tc, bktName, objName, emptyVersion)
 
-	require.False(t, existInMockedNeoFS(tc, bktInfo, objInfo))
+	require.False(t, existInMockedFrostFS(tc, bktInfo, objInfo))
 }
 
 func TestDeleteObjectFromSuspended(t *testing.T) {
@@ -109,7 +109,7 @@ func TestDeleteObjectVersioned(t *testing.T) {
 	deleteObject(t, tc, bktName, objName, objInfo.VersionID())
 	checkNotFound(t, tc, bktName, objName, objInfo.VersionID())
 
-	require.False(t, existInMockedNeoFS(tc, bktInfo, objInfo), "object exists but shouldn't")
+	require.False(t, existInMockedFrostFS(tc, bktInfo, objInfo), "object exists but shouldn't")
 }
 
 func TestDeleteObjectUnversioned(t *testing.T) {
@@ -126,7 +126,7 @@ func TestDeleteObjectUnversioned(t *testing.T) {
 	require.Len(t, versions.DeleteMarker, 0, "delete markers must be empty")
 	require.Len(t, versions.Version, 0, "versions must be empty")
 
-	require.False(t, existInMockedNeoFS(tc, bktInfo, objInfo), "object exists but shouldn't")
+	require.False(t, existInMockedFrostFS(tc, bktInfo, objInfo), "object exists but shouldn't")
 }
 
 func TestRemoveDeleteMarker(t *testing.T) {
@@ -144,7 +144,7 @@ func TestRemoveDeleteMarker(t *testing.T) {
 	deleteObject(t, tc, bktName, objName, deleteMarkerVersion)
 	checkFound(t, tc, bktName, objName, emptyVersion)
 
-	require.True(t, existInMockedNeoFS(tc, bktInfo, objInfo), "object doesn't exist but should")
+	require.True(t, existInMockedFrostFS(tc, bktInfo, objInfo), "object doesn't exist but should")
 }
 
 func TestDeleteObjectCombined(t *testing.T) {
@@ -161,7 +161,7 @@ func TestDeleteObjectCombined(t *testing.T) {
 
 	checkFound(t, tc, bktName, objName, objInfo.VersionID())
 
-	require.True(t, existInMockedNeoFS(tc, bktInfo, objInfo), "object doesn't exist but should")
+	require.True(t, existInMockedFrostFS(tc, bktInfo, objInfo), "object doesn't exist but should")
 }
 
 func TestDeleteObjectSuspended(t *testing.T) {
@@ -181,7 +181,7 @@ func TestDeleteObjectSuspended(t *testing.T) {
 	deleteObject(t, tc, bktName, objName, emptyVersion)
 	checkNotFound(t, tc, bktName, objName, objInfo.VersionID())
 
-	require.False(t, existInMockedNeoFS(tc, bktInfo, objInfo), "object exists but shouldn't")
+	require.False(t, existInMockedFrostFS(tc, bktInfo, objInfo), "object exists but shouldn't")
 }
 
 func TestDeleteMarkers(t *testing.T) {
@@ -200,7 +200,7 @@ func TestDeleteMarkers(t *testing.T) {
 	require.Len(t, versions.DeleteMarker, 3, "invalid delete markers length")
 	require.Len(t, versions.Version, 0, "versions must be empty")
 
-	require.Len(t, listOIDsFromMockedNeoFS(t, tc, bktName), 0, "shouldn't be any object in neofs")
+	require.Len(t, listOIDsFromMockedFrostFS(t, tc, bktName), 0, "shouldn't be any object in frostfs")
 }
 
 func TestDeleteObjectFromListCache(t *testing.T) {
@@ -220,7 +220,7 @@ func TestDeleteObjectFromListCache(t *testing.T) {
 	versions = listObjectsV1(t, tc, bktName, "", "", "", -1)
 	require.Len(t, versions.Contents, 0)
 
-	require.False(t, existInMockedNeoFS(tc, bktInfo, objInfo))
+	require.False(t, existInMockedFrostFS(tc, bktInfo, objInfo))
 }
 
 func TestDeleteObjectCheckMarkerReturn(t *testing.T) {

--- a/api/handler/handlers_test.go
+++ b/api/handler/handlers_test.go
@@ -31,7 +31,7 @@ type handlerContext struct {
 	owner   user.ID
 	t       *testing.T
 	h       *handler
-	tp      *layer.TestNeoFS
+	tp      *layer.TestFrostFS
 	context context.Context
 }
 
@@ -39,7 +39,7 @@ func (hc *handlerContext) Handler() *handler {
 	return hc.h
 }
 
-func (hc *handlerContext) MockedPool() *layer.TestNeoFS {
+func (hc *handlerContext) MockedPool() *layer.TestFrostFS {
 	return hc.tp
 }
 
@@ -68,7 +68,7 @@ func prepareHandlerContext(t *testing.T) *handlerContext {
 	require.NoError(t, err)
 
 	l := zap.NewExample()
-	tp := layer.NewTestNeoFS()
+	tp := layer.NewTestFrostFS()
 
 	testResolver := &resolver.Resolver{Name: "test_resolver"}
 	testResolver.SetResolveFunc(func(_ context.Context, name string) (cid.ID, error) {
@@ -208,7 +208,7 @@ func parseTestResponse(t *testing.T, response *httptest.ResponseRecorder, body i
 	require.NoError(t, err)
 }
 
-func existInMockedNeoFS(tc *handlerContext, bktInfo *data.BucketInfo, objInfo *data.ObjectInfo) bool {
+func existInMockedFrostFS(tc *handlerContext, bktInfo *data.BucketInfo, objInfo *data.ObjectInfo) bool {
 	p := &layer.GetObjectParams{
 		BucketInfo: bktInfo,
 		ObjectInfo: objInfo,
@@ -218,7 +218,7 @@ func existInMockedNeoFS(tc *handlerContext, bktInfo *data.BucketInfo, objInfo *d
 	return tc.Layer().GetObject(tc.Context(), p) == nil
 }
 
-func listOIDsFromMockedNeoFS(t *testing.T, tc *handlerContext, bktName string) []oid.ID {
+func listOIDsFromMockedFrostFS(t *testing.T, tc *handlerContext, bktName string) []oid.ID {
 	bktInfo, err := tc.Layer().GetBucketInfo(tc.Context(), bktName)
 	require.NoError(t, err)
 

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -313,7 +313,7 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func getCopiesNumberOrDefault(metadata map[string]string, defaultCopiesNumber uint32) (uint32, error) {
-	copiesNumberStr, ok := metadata[layer.AttributeNeofsCopiesNumber]
+	copiesNumberStr, ok := metadata[layer.AttributeFrostfsCopiesNumber]
 	if !ok {
 		return defaultCopiesNumber, nil
 	}

--- a/api/handler/put_test.go
+++ b/api/handler/put_test.go
@@ -114,7 +114,7 @@ func TestPutObjectOverrideCopiesNumber(t *testing.T) {
 	bktInfo := createTestBucket(tc, bktName)
 
 	w, r := prepareTestRequest(tc, bktName, objName, nil)
-	r.Header.Set(api.MetadataPrefix+strings.ToUpper(layer.AttributeNeofsCopiesNumber), "1")
+	r.Header.Set(api.MetadataPrefix+strings.ToUpper(layer.AttributeFrostfsCopiesNumber), "1")
 	tc.Handler().PutObjectHandler(w, r)
 
 	p := &layer.HeadObjectParams{
@@ -124,5 +124,5 @@ func TestPutObjectOverrideCopiesNumber(t *testing.T) {
 
 	objInfo, err := tc.Layer().GetObjectInfo(tc.Context(), p)
 	require.NoError(t, err)
-	require.Equal(t, "1", objInfo.Headers[layer.AttributeNeofsCopiesNumber])
+	require.Equal(t, "1", objInfo.Headers[layer.AttributeFrostfsCopiesNumber])
 }

--- a/api/headers.go
+++ b/api/headers.go
@@ -2,17 +2,17 @@ package api
 
 // Standard S3 HTTP request/response constants.
 const (
-	MetadataPrefix            = "X-Amz-Meta-"
-	NeoFSSystemMetadataPrefix = "S3-"
-	AmzMetadataDirective      = "X-Amz-Metadata-Directive"
-	AmzTaggingDirective       = "X-Amz-Tagging-Directive"
-	AmzVersionID              = "X-Amz-Version-Id"
-	AmzTaggingCount           = "X-Amz-Tagging-Count"
-	AmzTagging                = "X-Amz-Tagging"
-	AmzDeleteMarker           = "X-Amz-Delete-Marker"
-	AmzCopySource             = "X-Amz-Copy-Source"
-	AmzCopySourceRange        = "X-Amz-Copy-Source-Range"
-	AmzDate                   = "X-Amz-Date"
+	MetadataPrefix              = "X-Amz-Meta-"
+	FrostFSSystemMetadataPrefix = "S3-"
+	AmzMetadataDirective        = "X-Amz-Metadata-Directive"
+	AmzTaggingDirective         = "X-Amz-Tagging-Directive"
+	AmzVersionID                = "X-Amz-Version-Id"
+	AmzTaggingCount             = "X-Amz-Tagging-Count"
+	AmzTagging                  = "X-Amz-Tagging"
+	AmzDeleteMarker             = "X-Amz-Delete-Marker"
+	AmzCopySource               = "X-Amz-Copy-Source"
+	AmzCopySourceRange          = "X-Amz-Copy-Source-Range"
+	AmzDate                     = "X-Amz-Date"
 
 	LastModified       = "Last-Modified"
 	Date               = "Date"

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -41,14 +41,14 @@ func (n *layer) containerInfo(ctx context.Context, idCnr cid.ID) (*data.BucketIn
 			Name: idCnr.EncodeToString(),
 		}
 	)
-	res, err = n.neoFS.Container(ctx, idCnr)
+	res, err = n.frostFS.Container(ctx, idCnr)
 	if err != nil {
 		log.Error("could not fetch container", zap.Error(err))
 
 		if client.IsErrContainerNotFound(err) {
 			return nil, errors.GetAPIError(errors.ErrNoSuchBucket)
 		}
-		return nil, fmt.Errorf("get neofs container: %w", err)
+		return nil, fmt.Errorf("get frostfs container: %w", err)
 	}
 
 	cnr := *res
@@ -83,7 +83,7 @@ func (n *layer) containerList(ctx context.Context) ([]*data.BucketInfo, error) {
 		res []cid.ID
 		rid = api.GetRequestID(ctx)
 	)
-	res, err = n.neoFS.UserContainers(ctx, own)
+	res, err = n.frostFS.UserContainers(ctx, own)
 	if err != nil {
 		n.log.Error("could not list user containers",
 			zap.String("request_id", rid),
@@ -132,7 +132,7 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 		})
 	}
 
-	idCnr, err := n.neoFS.CreateContainer(ctx, PrmContainerCreate{
+	idCnr, err := n.frostFS.CreateContainer(ctx, PrmContainerCreate{
 		Creator:              bktInfo.Owner,
 		Policy:               p.Policy,
 		Name:                 p.Name,
@@ -158,9 +158,9 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 func (n *layer) setContainerEACLTable(ctx context.Context, idCnr cid.ID, table *eacl.Table, sessionToken *session.Container) error {
 	table.SetCID(idCnr)
 
-	return n.neoFS.SetContainerEACL(ctx, *table, sessionToken)
+	return n.frostFS.SetContainerEACL(ctx, *table, sessionToken)
 }
 
 func (n *layer) GetContainerEACL(ctx context.Context, idCnr cid.ID) (*eacl.Table, error) {
-	return n.neoFS.ContainerEACL(ctx, idCnr)
+	return n.frostFS.ContainerEACL(ctx, idCnr)
 }

--- a/api/layer/frostfs.go
+++ b/api/layer/frostfs.go
@@ -19,9 +19,9 @@ import (
 	"github.com/TrueCloudLab/frostfs-sdk-go/user"
 )
 
-// PrmContainerCreate groups parameters of NeoFS.CreateContainer operation.
+// PrmContainerCreate groups parameters of FrostFS.CreateContainer operation.
 type PrmContainerCreate struct {
-	// NeoFS identifier of the container creator.
+	// FrostFS identifier of the container creator.
 	Creator user.ID
 
 	// Container placement policy.
@@ -43,7 +43,7 @@ type PrmContainerCreate struct {
 	AdditionalAttributes [][2]string
 }
 
-// PrmAuth groups authentication parameters for the NeoFS operation.
+// PrmAuth groups authentication parameters for the FrostFS operation.
 type PrmAuth struct {
 	// Bearer token to be used for the operation. Overlaps PrivateKey. Optional.
 	BearerToken *bearer.Token
@@ -52,7 +52,7 @@ type PrmAuth struct {
 	PrivateKey *ecdsa.PrivateKey
 }
 
-// PrmObjectRead groups parameters of NeoFS.ReadObject operation.
+// PrmObjectRead groups parameters of FrostFS.ReadObject operation.
 type PrmObjectRead struct {
 	// Authentication parameters.
 	PrmAuth
@@ -73,7 +73,7 @@ type PrmObjectRead struct {
 	PayloadRange [2]uint64
 }
 
-// ObjectPart represents partially read NeoFS object.
+// ObjectPart represents partially read FrostFS object.
 type ObjectPart struct {
 	// Object header with optional in-memory payload part.
 	Head *object.Object
@@ -83,7 +83,7 @@ type ObjectPart struct {
 	Payload io.ReadCloser
 }
 
-// PrmObjectCreate groups parameters of NeoFS.CreateObject operation.
+// PrmObjectCreate groups parameters of FrostFS.CreateObject operation.
 type PrmObjectCreate struct {
 	// Authentication parameters.
 	PrmAuth
@@ -91,7 +91,7 @@ type PrmObjectCreate struct {
 	// Container to store the object.
 	Container cid.ID
 
-	// NeoFS identifier of the object creator.
+	// FrostFS identifier of the object creator.
 	Creator user.ID
 
 	// Key-value object attributes.
@@ -116,7 +116,7 @@ type PrmObjectCreate struct {
 	CopiesNumber uint32
 }
 
-// PrmObjectDelete groups parameters of NeoFS.DeleteObject operation.
+// PrmObjectDelete groups parameters of FrostFS.DeleteObject operation.
 type PrmObjectDelete struct {
 	// Authentication parameters.
 	PrmAuth
@@ -128,12 +128,12 @@ type PrmObjectDelete struct {
 	Object oid.ID
 }
 
-// ErrAccessDenied is returned from NeoFS in case of access violation.
+// ErrAccessDenied is returned from FrostFS in case of access violation.
 var ErrAccessDenied = errors.New("access denied")
 
-// NeoFS represents virtual connection to NeoFS network.
-type NeoFS interface {
-	// CreateContainer creates and saves parameterized container in NeoFS.
+// FrostFS represents virtual connection to FrostFS network.
+type FrostFS interface {
+	// CreateContainer creates and saves parameterized container in FrostFS.
 	// It sets 'Timestamp' attribute to the current time.
 	// It returns the ID of the saved container.
 	//
@@ -143,7 +143,7 @@ type NeoFS interface {
 	// prevented the container from being created.
 	CreateContainer(context.Context, PrmContainerCreate) (cid.ID, error)
 
-	// Container reads a container from NeoFS by ID.
+	// Container reads a container from FrostFS by ID.
 	//
 	// It returns exactly one non-nil value. It returns any error encountered which
 	// prevented the container from being read.
@@ -155,26 +155,26 @@ type NeoFS interface {
 	// prevented the containers from being listed.
 	UserContainers(context.Context, user.ID) ([]cid.ID, error)
 
-	// SetContainerEACL saves the eACL table of the container in NeoFS. The
+	// SetContainerEACL saves the eACL table of the container in FrostFS. The
 	// extended ACL is modified within session if session token is not nil.
 	//
 	// It returns any error encountered which prevented the eACL from being saved.
 	SetContainerEACL(context.Context, eacl.Table, *session.Container) error
 
-	// ContainerEACL reads the container eACL from NeoFS by the container ID.
+	// ContainerEACL reads the container eACL from FrostFS by the container ID.
 	//
 	// It returns exactly one non-nil value. It returns any error encountered which
 	// prevented the eACL from being read.
 	ContainerEACL(context.Context, cid.ID) (*eacl.Table, error)
 
-	// DeleteContainer marks the container to be removed from NeoFS by ID.
+	// DeleteContainer marks the container to be removed from FrostFS by ID.
 	// Request is sent within session if the session token is specified.
 	// Successful return does not guarantee actual removal.
 	//
 	// It returns any error encountered which prevented the removal request from being sent.
 	DeleteContainer(context.Context, cid.ID, *session.Container) error
 
-	// ReadObject reads a part of the object from the NeoFS container by identifier.
+	// ReadObject reads a part of the object from the FrostFS container by identifier.
 	// Exact part is returned according to the parameters:
 	//   * with header only: empty payload (both in-mem and reader parts are nil);
 	//   * with payload only: header is nil (zero range means full payload);
@@ -190,7 +190,7 @@ type NeoFS interface {
 	// prevented the object header from being read.
 	ReadObject(context.Context, PrmObjectRead) (*ObjectPart, error)
 
-	// CreateObject creates and saves a parameterized object in the NeoFS container.
+	// CreateObject creates and saves a parameterized object in the FrostFS container.
 	// It sets 'Timestamp' attribute to the current time.
 	// It returns the ID of the saved object.
 	//
@@ -202,7 +202,7 @@ type NeoFS interface {
 	// prevented the container from being created.
 	CreateObject(context.Context, PrmObjectCreate) (oid.ID, error)
 
-	// DeleteObject marks the object to be removed from the NeoFS container by identifier.
+	// DeleteObject marks the object to be removed from the FrostFS container by identifier.
 	// Successful return does not guarantee actual removal.
 	//
 	// It returns ErrAccessDenied on remove access violation.

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -45,7 +45,7 @@ type (
 	}
 
 	layer struct {
-		neoFS       NeoFS
+		frostFS     FrostFS
 		log         *zap.Logger
 		anonKey     AnonymousKey
 		resolver    BucketResolver
@@ -250,12 +250,12 @@ const (
 
 	AESEncryptionAlgorithm       = "AES256"
 	AESKeySize                   = 32
-	AttributeEncryptionAlgorithm = api.NeoFSSystemMetadataPrefix + "Algorithm"
-	AttributeDecryptedSize       = api.NeoFSSystemMetadataPrefix + "Decrypted-Size"
-	AttributeHMACSalt            = api.NeoFSSystemMetadataPrefix + "HMAC-Salt"
-	AttributeHMACKey             = api.NeoFSSystemMetadataPrefix + "HMAC-Key"
+	AttributeEncryptionAlgorithm = api.FrostFSSystemMetadataPrefix + "Algorithm"
+	AttributeDecryptedSize       = api.FrostFSSystemMetadataPrefix + "Decrypted-Size"
+	AttributeHMACSalt            = api.FrostFSSystemMetadataPrefix + "HMAC-Salt"
+	AttributeHMACKey             = api.FrostFSSystemMetadataPrefix + "HMAC-Key"
 
-	AttributeNeofsCopiesNumber = "neofs-copies-number" // such formate to match X-Amz-Meta-Neofs-Copies-Number header
+	AttributeFrostfsCopiesNumber = "frostfs-copies-number" // such format to match X-Amz-Meta-Frostfs-Copies-Number header
 )
 
 func (t *VersionedObject) String() string {
@@ -268,9 +268,9 @@ func (f MsgHandlerFunc) HandleMessage(ctx context.Context, msg *nats.Msg) error 
 
 // NewLayer creates an instance of a layer. It checks credentials
 // and establishes gRPC connection with the node.
-func NewLayer(log *zap.Logger, neoFS NeoFS, config *Config) Client {
+func NewLayer(log *zap.Logger, frostFS FrostFS, config *Config) Client {
 	return &layer{
-		neoFS:       neoFS,
+		frostFS:     frostFS,
 		log:         log,
 		anonKey:     config.AnonKey,
 		resolver:    config.Resolver,
@@ -377,7 +377,7 @@ func (n *layer) PutBucketACL(ctx context.Context, param *PutBucketACLParams) err
 }
 
 // ListBuckets returns all user containers. The name of the bucket is a container
-// id. Timestamp is omitted since it is not saved in neofs container.
+// id. Timestamp is omitted since it is not saved in frostfs container.
 func (n *layer) ListBuckets(ctx context.Context) ([]*data.BucketInfo, error) {
 	return n.containerList(ctx)
 }
@@ -661,5 +661,5 @@ func (n *layer) DeleteBucket(ctx context.Context, p *DeleteBucketParams) error {
 	}
 
 	n.cache.DeleteBucket(p.BktInfo.Name)
-	return n.neoFS.DeleteContainer(ctx, p.BktInfo.CID, p.SessionToken)
+	return n.frostFS.DeleteContainer(ctx, p.BktInfo.CID, p.SessionToken)
 }

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -311,7 +311,7 @@ func (n *layer) UploadPartCopy(ctx context.Context, p *UploadCopyParams) (*data.
 	return n.uploadPart(ctx, multipartInfo, params)
 }
 
-// implements io.Reader of payloads of the object list stored in the NeoFS network.
+// implements io.Reader of payloads of the object list stored in the FrostFS network.
 type multiObjectReader struct {
 	ctx context.Context
 

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -32,7 +32,7 @@ func (n *layer) PutLockInfo(ctx context.Context, p *PutLockInfoParams) (err erro
 	// sometimes node version can be provided from executing context
 	// if not, then receive node version from tree service
 	if versionNode == nil {
-		versionNode, err = n.getNodeVersionFromCacheOrNeofs(ctx, p.ObjVersion)
+		versionNode, err = n.getNodeVersionFromCacheOrFrostfs(ctx, p.ObjVersion)
 		if err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func (n *layer) PutLockInfo(ctx context.Context, p *PutLockInfoParams) (err erro
 	return nil
 }
 
-func (n *layer) getNodeVersionFromCacheOrNeofs(ctx context.Context, objVersion *ObjectVersion) (nodeVersion *data.NodeVersion, err error) {
+func (n *layer) getNodeVersionFromCacheOrFrostfs(ctx context.Context, objVersion *ObjectVersion) (nodeVersion *data.NodeVersion, err error) {
 	// check cache if node version is stored inside extendedObjectVersion
 	nodeVersion = n.getNodeVersionFromCache(n.Owner(ctx), objVersion)
 	if nodeVersion == nil {
@@ -228,7 +228,7 @@ func (n *layer) attributesFromLock(ctx context.Context, lock *data.ObjectLock) (
 	)
 
 	if lock.Retention != nil {
-		if _, expEpoch, err = n.neoFS.TimeToEpoch(ctx, TimeNow(ctx), lock.Retention.Until); err != nil {
+		if _, expEpoch, err = n.frostFS.TimeToEpoch(ctx, TimeNow(ctx), lock.Retention.Until); err != nil {
 			return nil, fmt.Errorf("fetch time to epoch: %w", err)
 		}
 
@@ -238,7 +238,7 @@ func (n *layer) attributesFromLock(ctx context.Context, lock *data.ObjectLock) (
 	}
 
 	if lock.LegalHold != nil && lock.LegalHold.Enabled {
-		// todo: (@KirillovDenis) reconsider this when NeoFS will support Legal Hold https://github.com/nspcc-dev/neofs-contract/issues/247
+		// todo: (@KirillovDenis) reconsider this when FrostFS will support Legal Hold https://github.com/nspcc-dev/neofs-contract/issues/247
 		// Currently lock object must have an expiration epoch.
 		// Besides we need to override retention expiration epoch since legal hold cannot be deleted yet.
 		expEpoch = math.MaxUint64

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -238,7 +238,7 @@ func (n *layer) attributesFromLock(ctx context.Context, lock *data.ObjectLock) (
 	}
 
 	if lock.LegalHold != nil && lock.LegalHold.Enabled {
-		// todo: (@KirillovDenis) reconsider this when FrostFS will support Legal Hold https://github.com/nspcc-dev/neofs-contract/issues/247
+		// todo: (@KirillovDenis) reconsider this when FrostFS will support Legal Hold https://github.com/TrueCloudLab/frostfs-contract/issues/2
 		// Currently lock object must have an expiration epoch.
 		// Besides we need to override retention expiration epoch since legal hold cannot be deleted yet.
 		expEpoch = math.MaxUint64

--- a/api/layer/tagging.go
+++ b/api/layer/tagging.go
@@ -38,7 +38,7 @@ func (n *layer) GetObjectTagging(ctx context.Context, p *GetObjectTaggingParams)
 
 	nodeVersion := p.NodeVersion
 	if nodeVersion == nil {
-		nodeVersion, err = n.getNodeVersionFromCacheOrNeofs(ctx, p.ObjectVersion)
+		nodeVersion, err = n.getNodeVersionFromCacheOrFrostfs(ctx, p.ObjectVersion)
 		if err != nil {
 			return "", nil, err
 		}
@@ -65,7 +65,7 @@ func (n *layer) GetObjectTagging(ctx context.Context, p *GetObjectTaggingParams)
 func (n *layer) PutObjectTagging(ctx context.Context, p *PutObjectTaggingParams) (nodeVersion *data.NodeVersion, err error) {
 	nodeVersion = p.NodeVersion
 	if nodeVersion == nil {
-		nodeVersion, err = n.getNodeVersionFromCacheOrNeofs(ctx, p.ObjectVersion)
+		nodeVersion, err = n.getNodeVersionFromCacheOrFrostfs(ctx, p.ObjectVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/api/layer/tree_service.go
+++ b/api/layer/tree_service.go
@@ -24,7 +24,7 @@ type TreeService interface {
 	GetNotificationConfigurationNode(ctx context.Context, bktInfo *data.BucketInfo) (oid.ID, error)
 
 	// PutNotificationConfigurationNode puts a node to a system tree
-	// and returns objectID of a previous notif config which must be deleted in NeoFS.
+	// and returns objectID of a previous notif config which must be deleted in FrostFS.
 	//
 	// If object id to remove is not found returns ErrNoNodeToRemove error.
 	PutNotificationConfigurationNode(ctx context.Context, bktInfo *data.BucketInfo, objID oid.ID) (oid.ID, error)
@@ -34,12 +34,12 @@ type TreeService interface {
 	// If object id is not found returns ErrNodeNotFound error.
 	GetBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) (oid.ID, error)
 
-	// PutBucketCORS puts a node to a system tree and returns objectID of a previous cors config which must be deleted in NeoFS.
+	// PutBucketCORS puts a node to a system tree and returns objectID of a previous cors config which must be deleted in FrostFS.
 	//
 	// If object id to remove is not found returns ErrNoNodeToRemove error.
 	PutBucketCORS(ctx context.Context, bktInfo *data.BucketInfo, objID oid.ID) (oid.ID, error)
 
-	// DeleteBucketCORS removes a node from a system tree and returns objID which must be deleted in NeoFS.
+	// DeleteBucketCORS removes a node from a system tree and returns objID which must be deleted in FrostFS.
 	//
 	// If object id to remove is not found returns ErrNoNodeToRemove error.
 	DeleteBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) (oid.ID, error)
@@ -69,7 +69,7 @@ type TreeService interface {
 	GetMultipartUpload(ctx context.Context, bktInfo *data.BucketInfo, objectName, uploadID string) (*data.MultipartInfo, error)
 
 	// AddPart puts a node to a system tree as a child of appropriate multipart upload
-	// and returns objectID of a previous part which must be deleted in NeoFS.
+	// and returns objectID of a previous part which must be deleted in FrostFS.
 	//
 	// If object id to remove is not found returns ErrNoNodeToRemove error.
 	AddPart(ctx context.Context, bktInfo *data.BucketInfo, multipartNodeID uint64, info *data.PartInfo) (oldObjIDToDelete oid.ID, err error)

--- a/api/layer/versioning_test.go
+++ b/api/layer/versioning_test.go
@@ -113,7 +113,7 @@ func (tc *testContext) checkListObjects(ids ...oid.ID) {
 }
 
 func (tc *testContext) getObjectByID(objID oid.ID) *object.Object {
-	for _, obj := range tc.testNeoFS.Objects() {
+	for _, obj := range tc.testFrostFS.Objects() {
 		id, _ := obj.ID()
 		if id.Equals(objID) {
 			return obj
@@ -123,12 +123,12 @@ func (tc *testContext) getObjectByID(objID oid.ID) *object.Object {
 }
 
 type testContext struct {
-	t         *testing.T
-	ctx       context.Context
-	layer     Client
-	bktInfo   *data.BucketInfo
-	obj       string
-	testNeoFS *TestNeoFS
+	t           *testing.T
+	ctx         context.Context
+	layer       Client
+	bktInfo     *data.BucketInfo
+	obj         string
+	testFrostFS *TestFrostFS
 }
 
 func prepareContext(t *testing.T, cachesConfig ...*CachesConfig) *testContext {
@@ -146,7 +146,7 @@ func prepareContext(t *testing.T, cachesConfig ...*CachesConfig) *testContext {
 			GateKey:     key.PublicKey(),
 		},
 	})
-	tp := NewTestNeoFS()
+	tp := NewTestFrostFS()
 
 	bktName := "testbucket1"
 	bktID, err := tp.CreateContainer(ctx, PrmContainerCreate{
@@ -176,9 +176,9 @@ func prepareContext(t *testing.T, cachesConfig ...*CachesConfig) *testContext {
 			Owner: owner,
 			CID:   bktID,
 		},
-		obj:       "obj1",
-		t:         t,
-		testNeoFS: tp,
+		obj:         "obj1",
+		t:           t,
+		testFrostFS: tp,
 	}
 }
 

--- a/api/metrics/api.go
+++ b/api/metrics/api.go
@@ -55,22 +55,22 @@ var (
 	httpStatsMetric      = new(HTTPStats)
 	httpRequestsDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "neofs_s3_request_seconds",
-			Help:    "Time taken by requests served by current NeoFS S3 Gate instance",
+			Name:    "frostfs_s3_request_seconds",
+			Help:    "Time taken by requests served by current FrostFS S3 Gate instance",
 			Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10},
 		},
 		[]string{"api"},
 	)
 )
 
-// Collects HTTP metrics for NeoFS S3 Gate in Prometheus specific format
+// Collects HTTP metrics for FrostFS S3 Gate in Prometheus specific format
 // and sends to the given channel.
 func collectHTTPMetrics(ch chan<- prometheus.Metric) {
 	for api, value := range httpStatsMetric.currentS3Requests.Load() {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName("neofs_s3", "requests", "current"),
-				"Total number of running s3 requests in current NeoFS S3 Gate instance",
+				prometheus.BuildFQName("frostfs_s3", "requests", "current"),
+				"Total number of running s3 requests in current FrostFS S3 Gate instance",
 				[]string{"api"}, nil),
 			prometheus.CounterValue,
 			float64(value),
@@ -81,8 +81,8 @@ func collectHTTPMetrics(ch chan<- prometheus.Metric) {
 	for api, value := range httpStatsMetric.totalS3Requests.Load() {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName("neofs_s3", "requests", "total"),
-				"Total number of s3 requests in current NeoFS S3 Gate instance",
+				prometheus.BuildFQName("frostfs_s3", "requests", "total"),
+				"Total number of s3 requests in current FrostFS S3 Gate instance",
 				[]string{"api"}, nil),
 			prometheus.CounterValue,
 			float64(value),
@@ -93,8 +93,8 @@ func collectHTTPMetrics(ch chan<- prometheus.Metric) {
 	for api, value := range httpStatsMetric.totalS3Errors.Load() {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName("neofs_s3", "errors", "total"),
-				"Total number of s3 errors in current NeoFS S3 Gate instance",
+				prometheus.BuildFQName("frostfs_s3", "errors", "total"),
+				"Total number of s3 errors in current FrostFS S3 Gate instance",
 				[]string{"api"}, nil),
 			prometheus.CounterValue,
 			float64(value),

--- a/api/metrics/collector.go
+++ b/api/metrics/collector.go
@@ -12,9 +12,9 @@ type stats struct {
 var (
 	versionInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "neofs_s3",
+			Namespace: "frostfs_s3",
 			Name:      "version_info",
-			Help:      "Version of current NeoFS S3 Gate instance",
+			Help:      "Version of current FrostFS S3 Gate instance",
 		},
 		[]string{
 			// current version
@@ -23,7 +23,7 @@ var (
 	)
 
 	statsMetrics = &stats{
-		desc: prometheus.NewDesc("neofs_s3_stats", "Statistics exposed by NeoFS S3 Gate instance", nil, nil),
+		desc: prometheus.NewDesc("frostfs_s3_stats", "Statistics exposed by FrostFS S3 Gate instance", nil, nil),
 	}
 )
 
@@ -37,8 +37,8 @@ func collectNetworkMetrics(ch chan<- prometheus.Metric) {
 	// Network Sent/Received Bytes (Outbound)
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
-			prometheus.BuildFQName("neofs_s3", "tx", "bytes_total"),
-			"Total number of bytes sent by current NeoFS S3 Gate instance",
+			prometheus.BuildFQName("frostfs_s3", "tx", "bytes_total"),
+			"Total number of bytes sent by current FrostFS S3 Gate instance",
 			nil, nil),
 		prometheus.CounterValue,
 		float64(httpStatsMetric.getInputBytes()),
@@ -46,8 +46,8 @@ func collectNetworkMetrics(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
-			prometheus.BuildFQName("neofs_s3", "rx", "bytes_total"),
-			"Total number of bytes received by current NeoFS S3 Gate instance",
+			prometheus.BuildFQName("frostfs_s3", "rx", "bytes_total"),
+			"Total number of bytes received by current FrostFS S3 Gate instance",
 			nil, nil),
 		prometheus.CounterValue,
 		float64(httpStatsMetric.getOutputBytes()),

--- a/api/notifications/controller.go
+++ b/api/notifications/controller.go
@@ -61,7 +61,7 @@ type (
 
 	EventRecord struct {
 		EventVersion      string            `json:"eventVersion"`
-		EventSource       string            `json:"eventSource"`         // neofs:s3
+		EventSource       string            `json:"eventSource"`         // frostfs:s3
 		AWSRegion         string            `json:"awsRegion,omitempty"` // empty
 		EventTime         time.Time         `json:"eventTime"`
 		EventName         string            `json:"eventName"`
@@ -199,7 +199,7 @@ func (c *Controller) SendNotifications(topics map[string]string, p *handler.Send
 
 func (c *Controller) SendTestNotification(topic, bucketName, requestID, HostID string, now time.Time) error {
 	event := &TestEvent{
-		Service:   "NeoFS S3",
+		Service:   "FrostFS S3",
 		Event:     "s3:TestEvent",
 		Time:      now,
 		Bucket:    bucketName,
@@ -220,7 +220,7 @@ func prepareEvent(p *handler.SendNotificationParams) *Event {
 		Records: []EventRecord{
 			{
 				EventVersion: EventVersion21,
-				EventSource:  "neofs:s3",
+				EventSource:  "frostfs:s3",
 				AWSRegion:    "",
 				EventTime:    p.Time,
 				EventName:    p.Event,

--- a/api/resolver/resolver.go
+++ b/api/resolver/resolver.go
@@ -19,9 +19,9 @@ const (
 // ErrNoResolvers returns when trying to resolve container without any resolver.
 var ErrNoResolvers = errors.New("no resolvers")
 
-// NeoFS represents virtual connection to the NeoFS network.
-type NeoFS interface {
-	// SystemDNS reads system DNS network parameters of the NeoFS.
+// FrostFS represents virtual connection to the FrostFS network.
+type FrostFS interface {
+	// SystemDNS reads system DNS network parameters of the FrostFS.
 	//
 	// It returns exactly on non-zero value. It returns any error encountered
 	// which prevented the parameter from being read.
@@ -29,7 +29,7 @@ type NeoFS interface {
 }
 
 type Config struct {
-	NeoFS      NeoFS
+	FrostFS    FrostFS
 	RPCAddress string
 }
 
@@ -134,7 +134,7 @@ func (r *BucketResolver) equals(resolverNames []string) bool {
 func newResolver(name string, cfg *Config) (*Resolver, error) {
 	switch name {
 	case DNSResolver:
-		return NewDNSResolver(cfg.NeoFS)
+		return NewDNSResolver(cfg.FrostFS)
 	case NNSResolver:
 		return NewNNSResolver(cfg.RPCAddress)
 	default:
@@ -142,17 +142,17 @@ func newResolver(name string, cfg *Config) (*Resolver, error) {
 	}
 }
 
-func NewDNSResolver(neoFS NeoFS) (*Resolver, error) {
-	if neoFS == nil {
+func NewDNSResolver(frostFS FrostFS) (*Resolver, error) {
+	if frostFS == nil {
 		return nil, fmt.Errorf("pool must not be nil for DNS resolver")
 	}
 
 	var dns ns.DNS
 
 	resolveFunc := func(ctx context.Context, name string) (cid.ID, error) {
-		domain, err := neoFS.SystemDNS(ctx)
+		domain, err := frostFS.SystemDNS(ctx)
 		if err != nil {
-			return cid.ID{}, fmt.Errorf("read system DNS parameter of the NeoFS: %w", err)
+			return cid.ID{}, fmt.Errorf("read system DNS parameter of the FrostFS: %w", err)
 		}
 
 		domain = name + "." + domain

--- a/api/response.go
+++ b/api/response.go
@@ -117,7 +117,7 @@ func WriteErrorResponse(w http.ResponseWriter, reqInfo *ReqInfo, err error) int 
 		code = e.HTTPStatusCode
 
 		switch e.Code {
-		case "SlowDown", "XNeoFSServerNotInitialized", "XNeoFSReadQuorum", "XNeoFSWriteQuorum":
+		case "SlowDown", "XFrostFSServerNotInitialized", "XFrostFSReadQuorum", "XFrostFSWriteQuorum":
 			// Set retry-after header to indicate user-agents to retry request after 120secs.
 			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
 			w.Header().Set(hdrRetryAfter, "120")

--- a/cmd/s3-gw/app_metrics.go
+++ b/cmd/s3-gw/app_metrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	namespace      = "neofs_s3_gw"
+	namespace      = "frostfs_s3_gw"
 	stateSubsystem = "state"
 	poolSubsystem  = "pool"
 

--- a/cmd/s3-gw/app_settings.go
+++ b/cmd/s3-gw/app_settings.go
@@ -121,9 +121,9 @@ const ( // Settings.
 
 	cmdListenAddress = "listen_address"
 
-	// Configuration of parameters of requests to NeoFS.
-	// Number of the object copies to consider PUT to NeoFS successful.
-	cfgSetCopiesNumber = "neofs.set_copies_number"
+	// Configuration of parameters of requests to FrostFS.
+	// Number of the object copies to consider PUT to FrostFS successful.
+	cfgSetCopiesNumber = "frostfs.set_copies_number"
 
 	// List of allowed AccessKeyID prefixes.
 	cfgAllowedAccessKeyIDPrefixes = "allowed_access_key_id_prefixes"
@@ -217,7 +217,7 @@ func newSettings() *viper.Viper {
 	flags.String(cmdConfig, "", "config path")
 
 	flags.Duration(cfgHealthcheckTimeout, defaultHealthcheckTimeout, "set timeout to check node health during rebalance")
-	flags.Duration(cfgConnectTimeout, defaultConnectTimeout, "set timeout to connect to NeoFS nodes")
+	flags.Duration(cfgConnectTimeout, defaultConnectTimeout, "set timeout to connect to FrostFS nodes")
 	flags.Duration(cfgRebalanceInterval, defaultRebalanceInterval, "set rebalance interval")
 
 	flags.Int(cfgMaxClientsCount, defaultMaxClientsCount, "set max-clients count")
@@ -227,7 +227,7 @@ func newSettings() *viper.Viper {
 	flags.String(cfgTLSCertFile, "", "TLS certificate file to use")
 	flags.String(cfgTLSKeyFile, "", "TLS key file to use")
 
-	peers := flags.StringArrayP(cfgPeers, "p", nil, "set NeoFS nodes")
+	peers := flags.StringArrayP(cfgPeers, "p", nil, "set FrostFS nodes")
 
 	flags.StringP(cfgRPCEndpoint, "r", "", "set RPC endpoint")
 	resolveMethods := flags.StringSlice(cfgResolveOrder, []string{resolver.DNSResolver}, "set bucket name resolve order")

--- a/config/config.env
+++ b/config/config.env
@@ -7,19 +7,19 @@ S3_GW_WALLET_ADDRESS=NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP
 S3_GW_WALLET_PASSPHRASE=s3
 
 # Nodes
-# This configuration makes the gateway use the first node (grpc://s01.neofs.devenv:8080)
-# while it's healthy. Otherwise, gateway uses the second node (grpc://s01.neofs.devenv:8080)
-# for 10% of requests and the third node (grpc://s03.neofs.devenv:8080) for 90% of requests.
+# This configuration makes the gateway use the first node (grpc://s01.frostfs.devenv:8080)
+# while it's healthy. Otherwise, gateway uses the second node (grpc://s01.frostfs.devenv:8080)
+# for 10% of requests and the third node (grpc://s03.frostfs.devenv:8080) for 90% of requests.
 # Until nodes with the same priority level are healthy
 # nodes with other priority are not used.
 # The lower the value, the higher the priority.
-S3_GW_PEERS_0_ADDRESS=grpc://s01.neofs.devenv:8080
+S3_GW_PEERS_0_ADDRESS=grpc://s01.frostfs.devenv:8080
 S3_GW_PEERS_0_PRIORITY=1
 S3_GW_PEERS_0_WEIGHT=1
-S3_GW_PEERS_1_ADDRESS=grpc://s02.neofs.devenv:8080
+S3_GW_PEERS_1_ADDRESS=grpc://s02.frostfs.devenv:8080
 S3_GW_PEERS_1_PRIORITY=2
 S3_GW_PEERS_1_WEIGHT=0.1
-S3_GW_PEERS_2_ADDRESS=grpc://s03.neofs.devenv:8080
+S3_GW_PEERS_2_ADDRESS=grpc://s03.frostfs.devenv:8080
 S3_GW_PEERS_2_PRIORITY=2
 S3_GW_PEERS_2_WEIGHT=0.9
 
@@ -34,7 +34,7 @@ S3_GW_SERVER_1_TLS_CERT_FILE=/path/to/tls/cert
 S3_GW_SERVER_1_TLS_KEY_FILE=/path/to/tls/key
 
 # Domains to be able to use virtual-hosted-style access to bucket.
-S3_GW_LISTEN_DOMAINS=s3dev.neofs.devenv
+S3_GW_LISTEN_DOMAINS=s3dev.frostfs.devenv
 
 # Config file
 S3_GW_CONFIG=/path/to/config/yaml
@@ -43,10 +43,10 @@ S3_GW_CONFIG=/path/to/config/yaml
 S3_GW_LOGGER_LEVEL=debug
 
 # Endpoint of the tree service. Must be provided. Can be one of the node address (from the `peers` section).
-S3_GW_TREE_SERVICE=grpc://s01.neofs.devenv:8080
+S3_GW_TREE_SERVICE=grpc://s01.frostfs.devenv:8080
 
 # RPC endpoint and order of resolving of bucket names
-S3_GW_RPC_ENDPOINT=http://morph-chain.neofs.devenv:30333/
+S3_GW_RPC_ENDPOINT=http://morph-chain.frostfs.devenv:30333/
 S3_GW_RESOLVE_ORDER="nns dns"
 
 # Metrics
@@ -97,14 +97,14 @@ S3_GW_CACHE_ACCESSCONTROL_SIZE=100000
 
 # NATS
 S3_GW_NATS_ENABLED=true
-S3_GW_NATS_ENDPOINT=nats://nats.neofs.devenv:4222
+S3_GW_NATS_ENDPOINT=nats://nats.frostfs.devenv:4222
 S3_GW_NATS_TIMEOUT=30s
 S3_GW_NATS_CERT_FILE=/path/to/cert
 S3_GW_NATS_KEY_FILE=/path/to/key
 S3_GW_NATS_ROOT_CA=/path/to/ca
 
-# Default policy of placing containers in NeoFS
-# If a user sends a request `CreateBucket` and doesn't define policy for placing of a container in NeoFS, the S3 Gateway
+# Default policy of placing containers in FrostFS
+# If a user sends a request `CreateBucket` and doesn't define policy for placing of a container in FrostFS, the S3 Gateway
 # will put the container with default policy. It can be specified via environment variable, e.g.:
 S3_GW_PLACEMENT_POLICY_DEFAULT_POLICY="REP 3"
 # Region to placement policy mapping json file.
@@ -115,10 +115,10 @@ S3_GW_PLACEMENT_POLICY_REGION_MAPPING=/path/to/container/policy.json
 # value of Access-Control-Max-Age header if this value is not set in a rule. Has an int type.
 S3_GW_CORS_DEFAULT_MAX_AGE=600
 
-# Parameters of requests to NeoFS
-# Number of the object copies to consider PUT to NeoFS successful.
+# Parameters of requests to FrostFS
+# Number of the object copies to consider PUT to FrostFS successful.
 # If not set, default value 0 will be used -- it means that object will be processed according to the container's placement policy
-S3_GW_NEOFS_SET_COPIES_NUMBER=0
+S3_GW_FROSTFS_SET_COPIES_NUMBER=0
 
 # List of allowed AccessKeyID prefixes
 # If not set, S3 GW will accept all AccessKeyIDs

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,23 +5,23 @@ wallet:
   address: NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP # Account address. If omitted default one will be used.
 
 # Nodes configuration
-# This configuration makes the gateway use the first node (grpc://s01.neofs.devenv:8080)
-# while it's healthy. Otherwise, gateway uses the second node (grpc://s01.neofs.devenv:8080)
-# for 10% of requests and the third node (grpc://s03.neofs.devenv:8080) for 90% of requests.
+# This configuration makes the gateway use the first node (grpc://s01.frostfs.devenv:8080)
+# while it's healthy. Otherwise, gateway uses the second node (grpc://s01.frostfs.devenv:8080)
+# for 10% of requests and the third node (grpc://s03.frostfs.devenv:8080) for 90% of requests.
 # Until nodes with the same priority level are healthy
 # nodes with other priority are not used.
 # The lower the value, the higher the priority.
 peers:
   0:
-    address: node1.neofs:8080
+    address: node1.frostfs:8080
     priority: 1
     weight: 1
   1:
-    address: node2.neofs:8080
+    address: node2.frostfs:8080
     priority: 2
     weight: 0.1
   2:
-    address: node3.neofs:8080
+    address: node3.frostfs:8080
     priority: 2
     weight: 0.9
 
@@ -39,17 +39,17 @@ server:
 
 # Domains to be able to use virtual-hosted-style access to bucket.
 listen_domains:
-  - s3dev.neofs.devenv
+  - s3dev.frostfs.devenv
 
 logger:
   level: debug
 
 # Endpoint of the tree service. Must be provided. Can be one of the node address (from the `peers` section).
 tree:
-  service: node1.neofs:8080
+  service: node1.frostfs:8080
 
 # RPC endpoint and order of resolving of bucket names
-rpc_endpoint: http://morph-chain.neofs.devenv:30333
+rpc_endpoint: http://morph-chain.frostfs.devenv:30333
 resolve_order:
   - nns
 
@@ -118,10 +118,10 @@ nats:
   key_file: /path/to/key
   root_ca: /path/to/ca
 
-# Parameters of NeoFS container placement policy
+# Parameters of FrostFS container placement policy
 placement_policy:
-  # Default policy of placing containers in NeoFS
-  # If a user sends a request `CreateBucket` and doesn't define policy for placing of a container in NeoFS, the S3 Gateway
+  # Default policy of placing containers in FrostFS
+  # If a user sends a request `CreateBucket` and doesn't define policy for placing of a container in FrostFS, the S3 Gateway
   # will put the container with default policy.
   default: REP 3
   # Region to placement policy mapping json file.
@@ -133,9 +133,9 @@ placement_policy:
 cors:
   default_max_age: 600
 
-# Parameters of requests to NeoFS
-neofs:
-  # Number of the object copies to consider PUT to NeoFS successful.
+# Parameters of requests to FrostFS
+frostfs:
+  # Number of the object copies to consider PUT to FrostFS successful.
   # `0` means that object will be processed according to the container's placement policy
   set_copies_number: 0
 

--- a/creds/accessbox/bearer_token_test.go
+++ b/creds/accessbox/bearer_token_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/TrueCloudLab/frostfs-sdk-go/bearer"
-	neofsecdsa "github.com/TrueCloudLab/frostfs-sdk-go/crypto/ecdsa"
+	frostfsecdsa "github.com/TrueCloudLab/frostfs-sdk-go/crypto/ecdsa"
 	"github.com/TrueCloudLab/frostfs-sdk-go/eacl"
 	"github.com/TrueCloudLab/frostfs-sdk-go/session"
 	"github.com/google/uuid"
@@ -89,7 +89,7 @@ func TestSessionTokenInAccessBox(t *testing.T) {
 	require.NoError(t, err)
 
 	tkn.SetID(uuid.New())
-	tkn.SetAuthKey((*neofsecdsa.PublicKey)(sec.PublicKey()))
+	tkn.SetAuthKey((*frostfsecdsa.PublicKey)(sec.PublicKey()))
 	require.NoError(t, tkn.Sign(sec.PrivateKey))
 
 	var newTkn bearer.Token

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ There are some custom types used for brevity:
 | `cors`             | [CORS configuration](#cors-section)                         |
 | `pprof`            | [Pprof configuration](#pprof-section)                       |
 | `prometheus`       | [Prometheus configuration](#prometheus-section)             |
-| `neofs`            | [Parameters of requests to FrostFS](#neofs-section)         |
+| `frostfs`          | [Parameters of requests to FrostFS](#frostfs-section)       |
 
 ### General section
 
@@ -447,10 +447,10 @@ prometheus:
 | `enabled` | `bool`   | yes           | `false`          | Flag to enable the service.             |
 | `address` | `string` | yes           | `localhost:8086` | Address that service listener binds to. |
 
-# `neofs` section
+# `frostfs` section
 
 Contains parameters of requests to FrostFS. 
-This value can be overridden with `X-Amz-Meta-Neofs-Copies-Number` header for `PutObject`, `CopyObject`, `CreateMultipartUpload`.
+This value can be overridden with `X-Amz-Meta-Frostfs-Copies-Number` header for `PutObject`, `CopyObject`, `CreateMultipartUpload`.
 
 ```yaml
 frostfs:

--- a/internal/frostfs/frostfs_test.go
+++ b/internal/frostfs/frostfs_test.go
@@ -1,4 +1,4 @@
-package neofs
+package frostfs
 
 import (
 	"fmt"

--- a/internal/frostfs/tree.go
+++ b/internal/frostfs/tree.go
@@ -1,4 +1,4 @@
-package neofs
+package frostfs
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	"github.com/TrueCloudLab/frostfs-s3-gw/api/data"
 	"github.com/TrueCloudLab/frostfs-s3-gw/api/layer"
 	"github.com/TrueCloudLab/frostfs-s3-gw/creds/accessbox"
-	"github.com/TrueCloudLab/frostfs-s3-gw/internal/neofs/services/tree"
+	"github.com/TrueCloudLab/frostfs-s3-gw/internal/frostfs/services/tree"
 	"github.com/TrueCloudLab/frostfs-sdk-go/bearer"
 	oid "github.com/TrueCloudLab/frostfs-sdk-go/object/id"
 	"github.com/TrueCloudLab/frostfs-sdk-go/user"

--- a/internal/frostfs/tree_signature.go
+++ b/internal/frostfs/tree_signature.go
@@ -1,5 +1,5 @@
-/*REMOVE THIS AFTER SIGNATURE WILL BE AVAILABLE IN TREE CLIENT FROM NEOFS NODE*/
-package neofs
+/*REMOVE THIS AFTER SIGNATURE WILL BE AVAILABLE IN TREE CLIENT FROM FROSTFS NODE*/
+package frostfs
 
 import (
 	crypto "github.com/TrueCloudLab/frostfs-crypto"

--- a/internal/frostfs/tree_test.go
+++ b/internal/frostfs/tree_test.go
@@ -1,4 +1,4 @@
-package neofs
+package frostfs
 
 import (
 	"errors"

--- a/syncTree.sh
+++ b/syncTree.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mkdir -p internal/neofs/services/tree 2>/dev/null
+mkdir -p internal/frostfs/services/tree 2>/dev/null
 
 REVISION="feaa9eace7098c343598bf08fb50746a1e8d2deb"
 
@@ -15,5 +15,5 @@ for file in $FILES; do
   else
     echo "sync '$file' in tree service"
   fi
-  curl -s "https://raw.githubusercontent.com/TrueCloudLab/frostfs-node/${REVISION}/pkg/services/tree/${file}" -o "./internal/neofs/services/tree/${file}"
+  curl -s "https://raw.githubusercontent.com/TrueCloudLab/frostfs-node/${REVISION}/pkg/services/tree/${file}" -o "./internal/frostfs/services/tree/${file}"
 done


### PR DESCRIPTION
Related to #2 
Based and blocked by #3 

**Note:** there are left some old mentions
* in [sync-tree](https://github.com/KirillovDenis/neofs-s3-gw/blob/1fea5d69c1e6ccccadff0e4c0560b472401b6ee1/syncTree.sh#L12) because file names aren't updated yet in [fork](https://github.com/TrueCloudLab/frostfs-node/tree/master/pkg/services/tree)
* `__NEOFS__EXPIRATION_EPOCH` because node doesn't support new attribute yet
*  [some](https://github.com/KirillovDenis/neofs-s3-gw/blob/1fea5d69c1e6ccccadff0e4c0560b472401b6ee1/internal/frostfs/tree_signature.go#L10) [links](https://github.com/KirillovDenis/neofs-s3-gw/blob/1fea5d69c1e6ccccadff0e4c0560b472401b6ee1/docs/s3_test_results.md?plain=1#L370) to closed issues

Also note that was renamed [some errors](https://github.com/KirillovDenis/neofs-s3-gw/blob/1fea5d69c1e6ccccadff0e4c0560b472401b6ee1/api/response.go#L120) because I couldn't find something similar in storage node