### PR TITLE
[TrueCloudLab#28] Add generated deb builder files to gitignore, and fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,11 @@ coverage.txt
 coverage.html
 
 # debhelpers
-**/.debhelper
+**/*debhelper*
+
+# debian package build files
+debian/files
+debian/*.log
+debian/*.substvars
+debian/frostfs-s3-gw/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This document outlines major changes between releases.
 - Update go version to go1.18 (TrueCloudLab#16)
 - Return error on invalid LocationConstraint (TrueCloudLab#23)
 - Place billing metrics to separate url path (TrueCloudLab#26)
+- Add generated deb builder files to .gitignore, and fix typo (TrueCloudLab#28)
 
 ## [0.26.0] - 2022-12-28
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-forstfs-s3-gw (0.0.0) stable; urgency=medium
+frostfs-s3-gw (0.0.0) stable; urgency=medium
 
   * Please see CHANGELOG.md
 


### PR DESCRIPTION
Now after build debian package, we see "dirty" suffix in version, example:
```
neofs-node --version
NeoFS Storage node
Version: v0.35.0-43-g3209d746-dirty
GoVersion: go1.18.4
```

It's happens because ```make debpackage``` download all dependencies in work directory, and after download git directory have uncommited changes. All changes are placed in debian folder and i'm solve this problem after add this files in .gitignore

Signed-off-by: Aleksey Pastukhov <a.pastukhov@yadro.com>