### PR TITLE
[TrueCloudLab#36] Fix cors object payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This document outlines major changes between releases.
 
 ## [Unreleased]
 
+### Fixed
+- Get empty bucket CORS from frostfs (TrueCloudLab#36)
+
 ### Added
 - Return container name in `head-bucket` response (TrueCloudLab#18)
 - Billing metrics (TrueCloudLab#5)

--- a/api/handler/cors_test.go
+++ b/api/handler/cors_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/TrueCloudLab/frostfs-s3-gw/api"
+)
+
+func TestCORSOriginWildcard(t *testing.T) {
+	body := `
+<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+	<CORSRule>
+		<AllowedMethod>GET</AllowedMethod>
+		<AllowedOrigin>*</AllowedOrigin>
+	</CORSRule>
+</CORSConfiguration>
+`
+	hc := prepareHandlerContext(t)
+
+	bktName := "bucket-for-cors"
+	box, _ := createAccessBox(t)
+	w, r := prepareTestRequest(hc, bktName, "", nil)
+	ctx := context.WithValue(r.Context(), api.BoxData, box)
+	r = r.WithContext(ctx)
+	r.Header.Add(api.AmzACL, "public-read")
+	hc.Handler().CreateBucketHandler(w, r)
+	assertStatus(t, w, http.StatusOK)
+
+	w, r = prepareTestPayloadRequest(hc, bktName, "", strings.NewReader(body))
+	ctx = context.WithValue(r.Context(), api.BoxData, box)
+	r = r.WithContext(ctx)
+	hc.Handler().PutBucketCorsHandler(w, r)
+	assertStatus(t, w, http.StatusOK)
+
+	w, r = prepareTestPayloadRequest(hc, bktName, "", nil)
+	hc.Handler().GetBucketCorsHandler(w, r)
+	assertStatus(t, w, http.StatusOK)
+}

--- a/api/layer/cors.go
+++ b/api/layer/cors.go
@@ -39,7 +39,7 @@ func (n *layer) PutBucketCORS(ctx context.Context, p *PutCORSParams) error {
 	prm := PrmObjectCreate{
 		Container:    p.BktInfo.CID,
 		Creator:      p.BktInfo.Owner,
-		Payload:      p.Reader,
+		Payload:      &buf,
 		Filepath:     p.BktInfo.CORSObjectName(),
 		CreationTime: TimeNow(ctx),
 		CopiesNumber: p.CopiesNumber,

--- a/api/layer/tree_mock.go
+++ b/api/layer/tree_mock.go
@@ -109,11 +109,32 @@ func (t *TreeServiceMock) PutNotificationConfigurationNode(ctx context.Context, 
 }
 
 func (t *TreeServiceMock) GetBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) (oid.ID, error) {
-	panic("implement me")
+	systemMap, ok := t.system[bktInfo.CID.EncodeToString()]
+	if !ok {
+		return oid.ID{}, nil
+	}
+
+	node, ok := systemMap["cors"]
+	if !ok {
+		return oid.ID{}, nil
+	}
+
+	return node.OID, nil
 }
 
 func (t *TreeServiceMock) PutBucketCORS(ctx context.Context, bktInfo *data.BucketInfo, objID oid.ID) (oid.ID, error) {
-	panic("implement me")
+	systemMap, ok := t.system[bktInfo.CID.EncodeToString()]
+	if !ok {
+		systemMap = make(map[string]*data.BaseNodeVersion)
+	}
+
+	systemMap["cors"] = &data.BaseNodeVersion{
+		OID: objID,
+	}
+
+	t.system[bktInfo.CID.EncodeToString()] = systemMap
+
+	return oid.ID{}, ErrNoNodeToRemove
 }
 
 func (t *TreeServiceMock) DeleteBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) (oid.ID, error) {


### PR DESCRIPTION
CORS objects were created with empty payload so we got  `"could not get cors","error":"unmarshal cors: EOF"`

Fix ceph tests:
* `test_cors_origin_wildcard`
* `test_cors_header_option`